### PR TITLE
Fix sha256sum for firefox-symbolic.svg

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -32,7 +32,7 @@ source=("hg+$_repo#tag=FIREFOX_${pkgver//./_}_RELEASE"
 	disable-pocket.diff disable-newtab-ads.diff add-restart.diff)
 sha256sums=('SKIP'
             '677e1bde4c6b3cff114345c211805c7c43085038ca0505718a11e96432e9811a'
-            '9a1a572dc88014882d54ba2d3079a1cf5b28fa03c5976ed2cb763c93dabbd797'
+            'a2474b32b9b2d7e0fb53a4c89715507ad1c194bef77713d798fa39d507def9e9'
             'e8a695bd6a007525390c502739c0f00d5d753a1bde7053c21c712075f2c2994d'
             'a94f80abe65608cd49054a30acc31e4d0885fe5b2a38cf08ded5e5b51b87c99d'
             'fb85a538044c15471c12cf561d6aa74570f8de7b054a7063ef88ee1bdfc1ccbb'


### PR DESCRIPTION
I was running `makepkg` and the sha256sum check failed for firefox-symbolic.svg. This fixes that error.